### PR TITLE
Correct address validation

### DIFF
--- a/address/static/address/js/address.js
+++ b/address/static/address/js/address.js
@@ -1,19 +1,16 @@
 $(function(){
-    $('input.address').each(function(){
-        var self = $(this);
-	var cmps = $('#' + self.attr('name') + '_components');
-	var fmtd = $('input[name="' + self.attr('name') + '_formatted"]');
-        self.geocomplete({
-            details: cmps,
-            detailsAttribute: 'data-geo'
-        }).change(function(){
-	    if(self.val() != fmtd.val()) {
-		var cmp_names = ['country', 'country_code', 'locality', 'postal_code',
-				 'route', 'street_number', 'state', 'state_code',
-				 'formatted', 'latitude', 'longitude'];
-		for(var ii = 0; ii < cmp_names.length; ++ii)
-		    $('input[name="' + self.attr('name') + '_' + cmp_names[ii] + '"]').val('');
-	    }
-	});
+  $('input.address').each(function(){
+    var self = $(this);
+    var cmps = $('#' + self.attr('name') + '_components');
+    var fmtd = $('input[name="' + self.attr('name') + '_formatted"]');
+    self.geocomplete({
+      details: cmps,
+      detailsAttribute: 'data-geo'
+    }).bind('geocode:error', function() {
+      self.val('');
+    }).bind('geocode:result', function () {
+      self.val(fmtd.val());
+    }).blur(function () {
+      self.val(fmtd.val());
     });
 });

--- a/address/static/address/js/address.js
+++ b/address/static/address/js/address.js
@@ -13,4 +13,5 @@ $(function(){
     }).blur(function () {
       self.val(fmtd.val());
     });
+  });
 });


### PR DESCRIPTION
Correct validation such that if the geocoded value is not valid, unset
the value of the field. If the field is valid, overwrite the value with
the returned formatted value, since that's what we're actually storing.
Finally, if the field blurs, just revert it back to the most recent
valid address.